### PR TITLE
Update image link handling to handle links with existing query parameters

### DIFF
--- a/lib/contentful_rails/markdown_renderer.rb
+++ b/lib/contentful_rails/markdown_renderer.rb
@@ -23,7 +23,10 @@ class ContentfulRails::MarkdownRenderer < Redcarpet::Render::HTML
 
   def image(link, title, alt_text)
     # add the querystring to the image
-    link += "?#{@image_parameters.to_query}"
+    if @image_parameters.present?
+      prefix = link.include?("?") ? "&" : "?"
+      link += "#{prefix}#{@image_parameters.to_query}"
+    end
     # return a content tag
     content_tag(:img, nil, src: link.to_s, alt: alt_text, title: title)
   end


### PR DESCRIPTION
This allows ContentfulRails::MarkdownRenderer to handle image URLs that include width and height parameters as part of the Contentful resizing API (e.g. http://someimage?width=10&height=50)
