### PR TITLE
✏️ Correct configuration options in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ ContentfulRails.configure do |config|
   config.preview_access_token = "your preview access token"
   config.management_token = "your management access token"
   config.space = "your space ID"
-  config.options = "hash of options"
+  config.contentful_options = {option: "value"}
 end
 ```
 


### PR DESCRIPTION
The ContentfulRails configuration block does not actually accept `config.options` ( [here](https://github.com/contentful/contentful_rails/blob/master/lib/contentful_rails.rb#L23) ) - but it does pass `config.contentful_options` to ContentfulModel ( [here](https://github.com/contentful/contentful_rails/blob/master/lib/contentful_rails/engine.rb#L19) )