### PR TITLE
Checking for entry_mapping config hash before eager loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,30 @@ pass to ContentfulModel in an initializer in the Rails engine.
 
 The default is to authenticate the webhooks; probably a smart move to host on an HTTPS endpoint too.
 
+### Entry Mapping
+
+By default, ContentfulRails will try to define your `entry_mapping` configuration for you.  It does this by iterating through
+ the descendents of the base class `ContentfulModel::Base` during initialization.  In order to ensure these classes are
+ loaded by this time, it will call `eager_load!` for the entire application.  If this is not desired, you can set the
+ `eager_load_entry_mapping` config to false set your entry mapping manually by setting the entry_mapping config
+  as [described here](https://github.com/contentful/contentful.rb#custom-resource-classes).
+
+
+```
+ContentfulRails.configure do |config|
+  ...
+  config.eager_load_entry_mapping = false
+  config.contentful_options = {
+    entry_mapping: {
+      'article' => Article,
+      ...
+    }
+  }
+end
+```
+
+**Note:** If you do not define the entry mapping in your configuration, the webhook cache expiration will likely not work as expected
+
 # Allowing 'Russian Doll' style caching on Entries
 The issue with 'Russian Doll' caching in Rails is that it requires a hit on the database to check the `updated_at` timestamp of an object.
 

--- a/lib/contentful_rails.rb
+++ b/lib/contentful_rails.rb
@@ -34,12 +34,14 @@ module ContentfulRails
                   :preview_username,
                   :preview_password,
                   :preview_domain,
-                  :enable_preview_domain
+                  :enable_preview_domain,
+                  :eager_load_entry_mapping
 
     def initialize
       @authenticate = true
       @slug_delimiter = "-"
       @perform_caching = Rails.configuration.action_controller.perform_caching
+      @eager_load_entry_mapping = true
       @contentful_options = {}
     end
   end

--- a/lib/contentful_rails/engine.rb
+++ b/lib/contentful_rails/engine.rb
@@ -23,8 +23,10 @@ module ContentfulRails
     #Iterate through all models which inherit from ContentfulModel::Base
     #and add an entry mapping for them, so calls to the Contentful API return
     #the appropriate classes
+    #If ContentfulModel.configuration.entry_mapping is already configured from
+    #initializer, assuming that is the one to use and not running `add_entry_mapping`
     initializer "add_entry_mappings", after: :configure_contentful  do
-      if defined?(ContentfulModel)
+      if defined?(ContentfulModel) && ContentfulModel.configuration.entry_mapping.blank?
         Rails.application.eager_load!
         ContentfulModel::Base.descendents.each do |klass|
           klass.send(:add_entry_mapping)

--- a/lib/contentful_rails/engine.rb
+++ b/lib/contentful_rails/engine.rb
@@ -24,7 +24,7 @@ module ContentfulRails
     #and add an entry mapping for them, so calls to the Contentful API return
     #the appropriate classes
     #If eager_load_entry_mapping is true, engine assumes entry mapping is set manually by
-    #Contentful.entry_mapping (set in ContentfulRails.contentful_options[:entry_mapping])
+    #ContentfulRails.contentful_options[:entry_mapping] (passed through to Contentful.entry_mapping config)
     initializer "add_entry_mappings", after: :configure_contentful  do
       if defined?(ContentfulModel) && ContentfulRails.configuration.eager_load_entry_mapping
         Rails.application.eager_load!

--- a/lib/contentful_rails/engine.rb
+++ b/lib/contentful_rails/engine.rb
@@ -23,7 +23,7 @@ module ContentfulRails
     #Iterate through all models which inherit from ContentfulModel::Base
     #and add an entry mapping for them, so calls to the Contentful API return
     #the appropriate classes
-    #If eager_load_entry_mapping is true, engine assumes entry mapping is set manually by
+    #If eager_load_entry_mapping is false, engine assumes entry mapping is set manually by
     #ContentfulRails.contentful_options[:entry_mapping] (passed through to Contentful.entry_mapping config)
     initializer "add_entry_mappings", after: :configure_contentful  do
       if defined?(ContentfulModel) && ContentfulRails.configuration.eager_load_entry_mapping

--- a/lib/contentful_rails/engine.rb
+++ b/lib/contentful_rails/engine.rb
@@ -23,10 +23,10 @@ module ContentfulRails
     #Iterate through all models which inherit from ContentfulModel::Base
     #and add an entry mapping for them, so calls to the Contentful API return
     #the appropriate classes
-    #If ContentfulModel.configuration.entry_mapping is already configured from
-    #initializer, assuming that is the one to use and not running `add_entry_mapping`
+    #If eager_load_entry_mapping is true, engine assumes entry mapping is set manually by
+    #Contentful.entry_mapping (set in ContentfulRails.contentful_options[:entry_mapping])
     initializer "add_entry_mappings", after: :configure_contentful  do
-      if defined?(ContentfulModel) && ContentfulModel.configuration.entry_mapping.blank?
+      if defined?(ContentfulModel) && ContentfulRails.configuration.eager_load_entry_mapping
         Rails.application.eager_load!
         ContentfulModel::Base.descendents.each do |klass|
           klass.send(:add_entry_mapping)


### PR DESCRIPTION
Might be way off base here, but according to [contentful gem documentation](https://github.com/contentful/contentful.rb#custom-resource-classes) you can specify the `entry_mapping` during configuration and don't need to rely on dynamic mapping.  So we can do:

```
ContentfulRails.configure do |config|
   ...
   config.contentful_options = {
      entry_mapping: {
          'article' => OurContentfulCms::Article
      }
   }
   ...
end
```

If this is present in the configuration, I think it should be safe to assume that this is the mapping that should be used for content_type classes and that we wouldn't need to do any `eager_load!`ing (which slows down boot ups and can cause issues in dev and test environments) to set up the entry mapping.

I don't think this should cause any issues with the ActiveSupport Notifications subscriptions or anything, but I may be missing a thing or to.  Just an idea :)