### PR TITLE
Fix for production env rails s on rails 5

### DIFF
--- a/app/controllers/contentful_rails/webhooks_controller.rb
+++ b/app/controllers/contentful_rails/webhooks_controller.rb
@@ -3,9 +3,9 @@ class ContentfulRails::WebhooksController < ActionController::Base
     http_basic_authenticate_with  name: ContentfulRails.configuration.webhooks_username,
                                   password: ContentfulRails.configuration.webhooks_password
   end
-  
-  protect_from_forgery with: :exception
-  skip_before_filter :verify_authenticity_token, :only => [:create]
+
+  # protect_from_forgery with: :exception
+  # skip_before_filter :verify_authenticity_token, :only => [:create]
 
   #this is where we receive a webhook, via a POST
   def create

--- a/app/controllers/contentful_rails/webhooks_controller.rb
+++ b/app/controllers/contentful_rails/webhooks_controller.rb
@@ -3,7 +3,8 @@ class ContentfulRails::WebhooksController < ActionController::Base
     http_basic_authenticate_with  name: ContentfulRails.configuration.webhooks_username,
                                   password: ContentfulRails.configuration.webhooks_password
   end
-
+  
+  protect_from_forgery with: :exception
   skip_before_filter :verify_authenticity_token, :only => [:create]
 
   #this is where we receive a webhook, via a POST

--- a/app/controllers/contentful_rails/webhooks_controller.rb
+++ b/app/controllers/contentful_rails/webhooks_controller.rb
@@ -1,12 +1,12 @@
 class ContentfulRails::WebhooksController < ActionController::Base
-  protect_from_forgery with: :exception
+  # protect_from_forgery with: :exception
 
   if ContentfulRails.configuration.authenticate_webhooks
     http_basic_authenticate_with  name: ContentfulRails.configuration.webhooks_username,
                                   password: ContentfulRails.configuration.webhooks_password
   end
 
-  skip_before_filter :verify_authenticity_token, :only => [:create]
+  # skip_before_filter :verify_authenticity_token, :only => [:create]
 
   #this is where we receive a webhook, via a POST
   def create

--- a/app/controllers/contentful_rails/webhooks_controller.rb
+++ b/app/controllers/contentful_rails/webhooks_controller.rb
@@ -6,8 +6,7 @@ class ContentfulRails::WebhooksController < ActionController::Base
                                   password: ContentfulRails.configuration.webhooks_password
   end
 
-  # protect_from_forgery with: :exception
-  # skip_before_filter :verify_authenticity_token, :only => [:create]
+  skip_before_filter :verify_authenticity_token, :only => [:create]
 
   #this is where we receive a webhook, via a POST
   def create

--- a/contentful_rails.gemspec
+++ b/contentful_rails.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "contentful_model", ">= 0.1.7"
+  s.add_dependency "contentful_model", ">= 0.2.0"
   s.add_dependency "rails", ">= 4.1.8"
   s.add_dependency "redcarpet", "~> 3.2"
 end

--- a/lib/contentful_rails/caching/timestamps.rb
+++ b/lib/contentful_rails/caching/timestamps.rb
@@ -7,8 +7,11 @@ module ContentfulRails
       def self.included(base)
         base.extend ClassMethods
         base.class_eval do
-          alias_method_chain :updated_at, :caching
-          alias_method_chain :cache_key, :preview
+          alias_method :updated_at_without_caching, :updated_at
+          alias_method :updated_at, :updated_at_with_caching
+
+          alias_method :cache_key_without_preview, :cache_key
+          alias_method :cache_key, :cache_key_with_preview
         end
       end
 

--- a/lib/contentful_rails/engine.rb
+++ b/lib/contentful_rails/engine.rb
@@ -54,7 +54,7 @@ module ContentfulRails
       content_type = "application/vnd.contentful.management.v1+json"
       Mime::Type.register "application/json", :contentful_json, [content_type]
 
-      ActionDispatch::ParamsParser::DEFAULT_PARSERS[Mime::Type.lookup(content_type)] = lambda do |body|
+      ActionDispatch::Request::DEFAULT_PARSERS[Mime::Type.lookup(content_type)] = lambda do |body|
         JSON.parse(body)
       end
     end


### PR DESCRIPTION
fixes "Before process_action callback :verify_authenticity_token has not been defined"

seems to be related to order of gem loading. skip_before_filter gets called before host app's ApplicationController loads to set protect_from_forgery