### PR TITLE
🐛 Define method which is being skipped

### DIFF
--- a/app/controllers/contentful_rails/webhooks_controller.rb
+++ b/app/controllers/contentful_rails/webhooks_controller.rb
@@ -1,4 +1,6 @@
 class ContentfulRails::WebhooksController < ActionController::Base
+  protect_from_forgery with: :exception
+
   if ContentfulRails.configuration.authenticate_webhooks
     http_basic_authenticate_with  name: ContentfulRails.configuration.webhooks_username,
                                   password: ContentfulRails.configuration.webhooks_password


### PR DESCRIPTION
As discussed here: http://stackoverflow.com/questions/39260198/verify-authenticity-token-has-not-been-defined in Rails 5 >= the server will raise an error when an attempt it made to skip a method which is not yet defined (as `verify_authenticity_token` is skipped in the webhooks controller)