### PR TITLE
Updating MIME registration to not override :json mime

### DIFF
--- a/lib/contentful_rails/engine.rb
+++ b/lib/contentful_rails/engine.rb
@@ -51,7 +51,12 @@ module ContentfulRails
     end
 
     initializer "add_contentful_mime_type" do
-      Mime::Type.register "application/json", :json, ["application/vnd.contentful.management.v1+json"]
+      content_type = "application/vnd.contentful.management.v1+json"
+      Mime::Type.register "application/json", :contentful_json, [content_type]
+
+      ActionDispatch::ParamsParser::DEFAULT_PARSERS[Mime::Type.lookup(content_type)] = lambda do |body|
+        JSON.parse(body)
+      end
     end
 
     initializer "add_preview_support" do


### PR DESCRIPTION
The way this initializer currently operates is by setting or overriding (depending on initializer load order) the default JSON mime type registered by Rails (https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/http/mime_types.rb#L31).   

This causes a few things:

1)  Warnings on every start up about `Mime::JSON` already being declared (written up in this issue https://github.com/contentful/contentful_rails/issues/2)
2a)  If this registration takes precedence, then it overrides the existing synonyms for the JSON content type that already exist (text/x-json and application/jsonrequest)
2b)  If the default Rails registration takes precedence, then this registration is lost and the webhook functionality doesn't work as ParamsParser does not recognize the incoming content type and therefore does not parse the payload into the `params` hash.

We've seen both scenarios 2a and 2b on two different projects so far.

I'm recommending with this change that, instead of re-registering the existing `:json` MIME type, we register a new custom type and then define how ParamsParser should parse the incoming payload when this content type is detected.