### PR TITLE
Ensure payload is parsed correctly in Rails 5

### DIFF
--- a/lib/contentful_rails/engine.rb
+++ b/lib/contentful_rails/engine.rb
@@ -60,13 +60,17 @@ module ContentfulRails
       end
     end
 
+    module ContentfulJSON
+      MIMETYPE = 'application/vnd.contentful.management.v1+json'.freeze
+    end
+
     initializer "add_contentful_mime_type" do
-      content_type = "application/vnd.contentful.management.v1+json"
-      Mime::Type.register content_type, :contentful_json, [content_type]
+      Mime::Type.register(ContentfulJSON::MIMETYPE, :contentful_json)
       default_parsers = Rails::VERSION::MAJOR > 4 ? ActionDispatch::Http::Parameters::DEFAULT_PARSERS : ActionDispatch::ParamsParser::DEFAULT_PARSERS
-      default_parsers[Mime::Type.lookup(content_type)] = lambda do |body|
+      default_parsers[Mime::Type.lookup(ContentfulJSON::MIMETYPE)] = lambda do |body|
         JSON.parse(body)
       end
+      ActionDispatch::Request.parameter_parsers = ActionDispatch::Request::DEFAULT_PARSERS if ActionDispatch::Request.respond_to?(:parameter_parsers=)
     end
 
     initializer "add_preview_support" do


### PR DESCRIPTION
Having run into this issue https://github.com/contentful/contentful_rails/issues/36 I noticed that the `payload` [engine.rb#L43](https://github.com/contentful/contentful_rails/blob/master/lib/contentful_rails/engine.rb#L43) was `nil` as the params were not being parsed by the custom mime type. 

Did some researching and found that in Rails 5 `ActionDispatch::Request.parameter_parsers` needs to be set as well in order to ensure `JSON` `payloads` are parsed correctly as noted here https://github.com/fotinakis/jsonapi-serializers/blob/master/README.md#rails-example.

Did some testing on our `Rails 5.0.0.1` app and the webhooks are now all returning `200` as the payload is parsed as expected.

![screen shot 2017-09-29 at 09 59 03](https://user-images.githubusercontent.com/810107/31009397-2ffe8f1e-a4ff-11e7-9cff-2ae8d4713507.png)


