### PR TITLE
render nothing has been depreciated in Rails 5.1

### DIFF
--- a/app/controllers/contentful_rails/webhooks_controller.rb
+++ b/app/controllers/contentful_rails/webhooks_controller.rb
@@ -30,7 +30,7 @@ class ContentfulRails::WebhooksController < ActionController::Base
     ActiveSupport::Notifications.instrument("Contentful.#{update_type}", params)
 
     #must return an ok
-    render nothing: true
+    head :ok
   end
 
   def debug


### PR DESCRIPTION
the `:nothing` option has been removed in Rails 5.1 (https://github.com/rails/rails/blob/1099329be081297c16b02141ec13ca6a05ff037c/actionpack/lib/action_controller/metal/rendering.rb#L101) 

This currently causes the following error 
```
ActionView::MissingTemplate: Missing template contentful_rails/webhooks/create with {:locale=>[:"en-GB", :en], :formats=>[:json], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby]}. Searched in: * "/app/app/views" * "/app/vendor/bundle/ruby/2.3.0/gems/devise_invitable-1.7.0/app/views" * "/app/vendor/bundle/ruby/2.3.0/gems/devise-4.3.0/app/views" * "/app/vendor/bundle/ruby/2.3.0/bundler/gems/contentful_rails-7658c4bc485f/app/views"
```

Proposing to use `head :ok` instead.