### PR TITLE
Fixed webhooks/debug for Rails >= 5.1

### DIFF
--- a/app/controllers/contentful_rails/webhooks_controller.rb
+++ b/app/controllers/contentful_rails/webhooks_controller.rb
@@ -34,7 +34,7 @@ class ContentfulRails::WebhooksController < ActionController::Base
   end
 
   def debug
-    render text: "Debug method works ok"
+    render plain: "Debug method works ok"
   end
 
   private


### PR DESCRIPTION
`:text` option has been removed in Rails 5.1. It causes errors when checking webhooks in dev mode. 