### PR TITLE
Issue 39 - Fix webhooks to work with Rails 5.1

### DIFF
--- a/app/controllers/contentful_rails/webhooks_controller.rb
+++ b/app/controllers/contentful_rails/webhooks_controller.rb
@@ -7,7 +7,7 @@ class ContentfulRails::WebhooksController < ActionController::Base
   end
 
   params = [:verify_authenticity_token, {:only => [:create], raise: false}]
-  if Rails::VERSION::MAJOR > 4 
+  if Rails::VERSION::MAJOR > 4
     skip_before_action *params
   else
     skip_before_filter *params
@@ -29,8 +29,8 @@ class ContentfulRails::WebhooksController < ActionController::Base
     # implement your own and subscribe in an initializer.
     ActiveSupport::Notifications.instrument("Contentful.#{update_type}", params)
 
-    #must return an ok
-    head :ok
+    #must return an empty response
+    render body: nil
   end
 
   def debug

--- a/lib/contentful_rails/version.rb
+++ b/lib/contentful_rails/version.rb
@@ -1,3 +1,3 @@
 module ContentfulRails
-  VERSION = "0.4.1"
+  VERSION = "0.4.2"
 end


### PR DESCRIPTION
Using ```head :ok``` has not worked and it breaks the app with a template missing error.

ActiveSupport::Deprecation.warn(":nothing option is deprecated and will be removed in Rails 5.1. Use `head` method to respond with empty response body.")

The above says to respond with an empty body but in the PR that's merged it's responding with ok `head :ok` which certain posts indicate it doesn't work!

https://stackoverflow.com/questions/34688726/the-nothing-option-is-deprecated-and-will-be-removed-in-rails-5-1/34688727#34688727

Replacing it with `render body: nil` has worked and we can get a webhook response.

I couldn't get RSpec running it was coming with error message unable to load Bundler. Emailed the active developer.

Using `head :ok`

<img width="1617" alt="broken webhooks" src="https://user-images.githubusercontent.com/12385311/34672718-72f57cc0-f477-11e7-86ad-2cdf9c138caf.png">

Using `render body: nil`

<img width="1617" alt="fixed webhooks" src="https://user-images.githubusercontent.com/12385311/34672736-83dd95cc-f477-11e7-8c7c-d0c214ee8f22.png">


  