### PR TITLE
Check that username and password are defined before asking for them

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,22 @@ end
 
 You can overload any methods exposed in RedCarpet.
 
+# Preview API
+ContenfulRails can be set up to use the [Contenful Preview API](https://www.contentful.com/developers/docs/references/content-preview-api/), and has the option of protecting that content behind basic authentication.
+To enable the preview api, add the below settings to your configuration.
+
+```
+ContentfulRails.configure do |config|
+  config.enable_preview_domain = true # use the preview domain
+  config.preview_access_token = "your preview access token"
+  config.preview_username = "a basic auth username"
+  config.preview_password = "a basic auth password"
+end
+```
+
+If you site is already protected with another form of authentication, then leave `preview_username` and `preview_password` unset.
+This will skip the authentication step when displaying preview content.
+
 # To Do
 Some things would be nice to do:
 

--- a/lib/contentful_rails/preview.rb
+++ b/lib/contentful_rails/preview.rb
@@ -20,6 +20,11 @@ module ContentfulRails
 
       # check subdomain matches the configured one - we assume it's first sub.domain.in.the.array
       if request.subdomains.first == ContentfulRails.configuration.preview_domain
+        if ContentfulRails.configuration.preview_username.nil? && ContentfulRails.configuration.preview_password.nil?
+          ContentfulModel.use_preview_api = true
+          return
+        end
+
         authenticated = authenticate_with_http_basic do |u, p|
           u == ContentfulRails.configuration.preview_username &&
             p == ContentfulRails.configuration.preview_password


### PR DESCRIPTION
**My use case**
We have a separate domain which has been set up to display draft Contentful content. This domain is already protected by basic auth, so we don't need an extra layer of basic auth around the Contentful content itself.

**Proposed solution**
Only ask for the username and password if they have both been defined in `preview_username` and `preview_password`. This allows existing users of the preview api to continue protecting it with basic auth, but it also allows users like myself to have their authentication somewhere else.