### PR TITLE
Remove connection to ActiveRecord

### DIFF
--- a/lib/contentful_rails.rb
+++ b/lib/contentful_rails.rb
@@ -52,5 +52,3 @@ module ContentfulRails
     end
   end
 end
-
-ActiveRecord::Migration.send(:include, ContentfulModel::Migrations::Migration)


### PR DESCRIPTION
If you want to use `contentful_rails` without ActiveRecord, this line would fail the app.

I also don't see the point of adding migrations here, since you are not storing anything to database, but directly to contentful.