### PR TITLE
Documenting on preview_domain in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ To enable the preview api, add the below settings to your configuration.
 ```
 ContentfulRails.configure do |config|
   config.enable_preview_domain = true # use the preview domain
+  config.preview_domain = "first portion of preview subdomain `sub.domain`"
   config.preview_access_token = "your preview access token"
   config.preview_username = "a basic auth username"
   config.preview_password = "a basic auth password"


### PR DESCRIPTION
Adding the need to set the `preview_domain` in config as well, since this is required for the Content Preview API to be called by the application. Otherwise this conditional will always default to `false` for `use_preview_api`: https://github.com/contentful/contentful_rails/blob/e8078156d4d81024be297ca62baa4a72971c14e8/lib/contentful_rails/preview.rb#L22