### PR TITLE
Don't raise error on unpublish webhook event for MemCacheStore

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ This will give you 2 routes:
 ## What the webhook handler does
 At the moment all this does is delete the timestamp cache entry, which means that a subsequent call to `updated_at` calls the API.
 
+## Note on MemCacheStore and Webhooks `unpublish` call
+`#delete_matched` method isn't and [won't be supported by MemCacheStore](https://github.com/petergoldstein/dalli/issues/397),
+and there is no way to expire all fragments, referenced by `unpublish` webhook event.
+
 # View Helpers
 Contentful has a [really nice url-based image manipulation API](https://www.contentful.com/blog/2014/08/14/do-more-with-images-on-contentful-platform/).
 

--- a/contentful_rails.gemspec
+++ b/contentful_rails.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'rubocop', '~> 0.49.0'
   s.add_development_dependency 'pg'
+  s.add_development_dependency 'dalli'
 end

--- a/lib/contentful_rails/engine.rb
+++ b/lib/contentful_rails/engine.rb
@@ -54,6 +54,8 @@ module ContentfulRails
 
       ActiveSupport::Notifications.subscribe(/Contentful.*Entry\.unpublish/) do |_name, _start, _finish, _id, payload|
         ActionController::Base.new.expire_fragment(%r{/.*#{payload[:sys][:id]}.*/})
+      rescue NotImplementedError => e
+        Rails.logger.error(e)
       end
     end
 

--- a/spec/lib/engine_spec.rb
+++ b/spec/lib/engine_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe ContentfulRails::Engine do
+  describe "subscribe_to_webhook_events" do
+    describe "unpublish" do
+      let(:event) { "Contentful.Entry.unpublish" }
+      let(:params) { { sys: { id: "fake_content_id" } } }
+      let(:cache_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
+
+      before do
+        allow_any_instance_of(ActionController::Base).to receive(:cache_store).and_return(cache_store)
+        allow_any_instance_of(ActionController::Base).to receive(:cache_configured?).and_return(true)
+      end
+
+      subject { ActiveSupport::Notifications.instrument(event, params) }
+
+      it "passes delete_matched to the store" do
+        expect(cache_store).to receive(:delete_matched)
+        subject
+      end
+
+      context "MemCacheStore" do
+        let(:cache_store) { ActiveSupport::Cache.lookup_store(:mem_cache_store) }
+
+        it "doesn't raise error" do
+          expect { subject }.not_to raise_error
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem
Rails MemCacheStore [doesn't support `delete_matched`](https://github.com/petergoldstein/dalli/issues/397), and if you use MemCacheStore, `unpublish` webhook will raise error.

## Solution
Maybe ugly, but it just rescues `NotImplementedError`.

Closes #25 